### PR TITLE
Metainfo: Description suggestions

### DIFF
--- a/data/com.github.HypatiaProject.hypatia.appdata.xml.in
+++ b/data/com.github.HypatiaProject.hypatia.appdata.xml.in
@@ -28,7 +28,7 @@
   </screenshots>
 
   <description>
-    <p>Get at-a-glance information about the topics you're reading, or learn things you're curious about. Hypatia find definitions, explanations, and answers related to the text on your display without removing you from the context or making you navigate away.</p>
+    <p>Get at-a-glance information about what you're reading, or learn more about topics you're curious about. Hypatia finds definitions, explanations, and answers related to the text on your display without removing you from the context or making you navigate away.</p>
 
     <p>Use Hypatia either of two ways: manually, where you open the app and enter a word or phrase to search for, or automatically, where it reads text from your clipboard on launch, and can be triggered by a shortcut.</p>
 

--- a/data/com.github.HypatiaProject.hypatia.appdata.xml.in
+++ b/data/com.github.HypatiaProject.hypatia.appdata.xml.in
@@ -28,13 +28,13 @@
   </screenshots>
 
   <description>
-    <p>Hypatia is a research tool for the Linux desktop. It's designed to provide at-a-glance information about the topics you're reading, or about things you're curious about. It lets you find definitions, explanations, and answers related to the text on your display without removing you from the context or making you navigate away.</p>
+    <p>Get at-a-glance information about the topics you're reading, or learn things you're curious about. Hypatia find definitions, explanations, and answers related to the text on your display without removing you from the context or making you navigate away.</p>
 
-    <p>There are two ways the application can function: manually, where you open the app and enter a word or phrase to search for, or automatically, where it reads text from your clipboard on launch, and can be triggered by a shortcut.</p>
+    <p>Use Hypatia either of two ways: manually, where you open the app and enter a word or phrase to search for, or automatically, where it reads text from your clipboard on launch, and can be triggered by a shortcut.</p>
 
     <p>Once you set a keyboard shortcut to open the app, you can copy text from the article you're reading, trigger the app, and a pop-up will give you instant information about whatever it is you're looking at.</p>
 
-    <p>Or, if you prefer to use it in manual mode, you can open it and search directly for any topic by entering it into the search box.</p>
+    <p>Or, if you prefer to use it in manual mode, you can open Hypatia and search directly for any topic by entering it into the search box.</p>
 
     <p>At launch, there are three main action areas:</p>
 


### PR DESCRIPTION
Just some suggestions after reading your app's description on Flathub. 😉 Here's the thinking:

1. Don't repeat the summary, as it's always shown above the description
2. Don't start the description with the name of the app, I think this is even a warning in the AppStream validator?
3. Don't need to specify it's for Linux; this description will only ever be shown in Linux App stores
4. Handful of other little tweaks

No worries if you disagree or want to tweak the description in other ways!