### PR TITLE
Make the abstract-text scrollable without needing to scroll the whole window

### DIFF
--- a/src/InstantAnswersBox.vala
+++ b/src/InstantAnswersBox.vala
@@ -23,6 +23,7 @@ namespace Hypatia {
 	    private Gtk.Label abstract_text_label;
 	    private Gtk.Label source_label;
 	    private Gtk.Image image;
+	    private Gtk.ScrolledWindow abstract_text_scrolled;
 
 	    private string NOT_FOUND_TEXT = _("No instant answer found");
 
@@ -34,14 +35,24 @@ namespace Hypatia {
             heading_label = new Gtk.Label(NOT_FOUND_TEXT);
             heading_label.get_style_context().add_class("title-1");
             heading_label.halign = Gtk.Align.START;
+            
             abstract_text_label = new Gtk.Label("");
-            abstract_text_label.set_max_width_chars(40);
             abstract_text_label.set_wrap(true);
             abstract_text_label.halign = Gtk.Align.START;
+            abstract_text_label.valign = Gtk.Align.START;
             abstract_text_label.justify = Gtk.Justification.FILL;
+            abstract_text_label.hexpand = true;            
+            abstract_text_label.vexpand = true;
+            
+            abstract_text_scrolled = new Gtk.ScrolledWindow();
+            abstract_text_scrolled.hexpand = true;
+            abstract_text_scrolled.vexpand = true;
+            abstract_text_scrolled.set_child(abstract_text_label);
+            
             image = new Gtk.Image();
 
             var left_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 12);
+            
             var right_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 12);
             right_box.get_style_context().add_class("card");
             right_box.valign = Gtk.Align.START;
@@ -51,7 +62,7 @@ namespace Hypatia {
             source_label.get_style_context().add_class("accent");
 
             left_box.append(heading_label);
-            left_box.append(abstract_text_label);
+            left_box.append(abstract_text_scrolled);
             left_box.append(source_label);
             left_box.hexpand = true;
             right_box.append(image);

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -27,7 +27,6 @@ namespace Hypatia {
 	    private WikipediaBox wikipedia_box;
 
 	    private Adw.Carousel carousel;
-	    private Gtk.ScrolledWindow answers_scrolled;
 
 	    private Gtk.Entry search_entry;
 
@@ -285,12 +284,6 @@ namespace Hypatia {
             header.pack_end(search_term_revealer);
             header.pack_end(loading_spinner);
 
-			answers_scrolled = new Gtk.ScrolledWindow();
-			answers_scrolled.set_child(answers_box);
-			answers_scrolled.vexpand = true;
-			answers_scrolled.hexpand = true;
-			answers_scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
-
 			var dictionary_scrolled = new Gtk.ScrolledWindow();
 			dictionary_scrolled.set_child(dictionary_box);
 			dictionary_scrolled.vexpand = true;
@@ -306,7 +299,7 @@ namespace Hypatia {
             if(app.settings.get_boolean("show-welcome")) {
                 carousel.append(welcome_box);
             }
-            carousel.append(answers_scrolled);
+            carousel.append(answers_box);
             carousel.append(dictionary_scrolled);
             carousel.append(wikipedia_scrolled);
 
@@ -327,7 +320,7 @@ namespace Hypatia {
             button_revealer.set_child(button_box);
 
             instant_answers_button.clicked.connect(() => {
-                carousel.scroll_to(answers_scrolled, true);
+                carousel.scroll_to(answers_box, true);
             });
 
             dictionary_button.clicked.connect(() => {
@@ -340,7 +333,7 @@ namespace Hypatia {
 
             welcome_box.next_page_selected.connect(() => {
                 carousel.remove(welcome_box);
-                carousel.scroll_to(answers_scrolled, true);
+                carousel.scroll_to(answers_box, true);
                 if (app.settings.get_boolean("first-launch")) {
                     app.settings.set_boolean("show-welcome", false);
                     app.settings.set_boolean("first-launch", false);


### PR DESCRIPTION
the reader must see what he searched for (Title & Image) even when he scrolled down.
 
### **From this** :
![Screenshot from 2022-04-09 15-46-31](https://user-images.githubusercontent.com/66528793/162576998-c9992395-605d-4af3-b1d8-dc5514d9b603.png)
==========
### **To this :**
![Screenshot from 2022-04-09 15-45-11](https://user-images.githubusercontent.com/66528793/162577028-754469ea-03a0-4f4d-9e90-8e51e4eed4c9.png)


