### PR TITLE
Update hypatia runtime to 46

### DIFF
--- a/com.github.HypatiaProject.hypatia.json
+++ b/com.github.HypatiaProject.hypatia.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.github.HypatiaProject.hypatia",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "42",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "command" : "hypatia",
     "finish-args" : [
@@ -24,6 +24,20 @@
         "*.a"
     ],
     "modules" : [
+        {
+            "name": "libsoup-2.4",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dtests=false"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/libsoup/2.74/libsoup-2.74.3.tar.xz",
+                    "sha256": "e4b77c41cfc4c8c5a035fcdc320c7bc6cfb75ef7c5a034153df1413fa1d92f13"
+                }
+            ]
+        },
         {
             "name" : "hypatia",
             "builddir" : true,

--- a/data/com.github.HypatiaProject.hypatia.appdata.xml.in
+++ b/data/com.github.HypatiaProject.hypatia.appdata.xml.in
@@ -5,12 +5,14 @@
   <metadata_license>CC0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <name>Hypatia</name>
-  <summary>A research helper tool that provides context and information about
-    interesting topics.
-  </summary>
+  <summary>A research helper tool that provides context and information about interesting topics</summary>
   <developer_name>Nathan Dyer and Hypatia Project Contributors</developer_name>
+  <developer id="io.github.hypatiaproject">
+    <name>Nathan Dyer and Hypatia Project Contributors</name>
+  </developer>
   <url type="homepage">https://github.com/HypatiaProject/hypatia</url>
   <url type="bugtracker">https://github.com/HypatiaProject/hypatia/issues</url>
+  <url type="vcs-browser">https://github.com/HypatiaProject/hypatia</url>
 
   <screenshots>
     <screenshot type="default">

--- a/data/com.github.HypatiaProject.hypatia.desktop.in
+++ b/data/com.github.HypatiaProject.hypatia.desktop.in
@@ -4,5 +4,6 @@ Exec=hypatia
 Icon=com.github.HypatiaProject.hypatia
 Terminal=false
 Type=Application
-Categories=GTK;
+Categories=Utility;
+Keywords=Research;Wikipedia;Wiktionary;definition;explanation;
 StartupNotify=true


### PR DESCRIPTION
- runtime: Update runtime to 46
- build: Add missing libsoup
- appdata: Add vcs-browser URL and developer block
- desktop: Fix category related issues and add a few keywords